### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 
     "require": {
         "php": "~7.0",
-        "illuminate/support": "~5.4"
+        "illuminate/support": "5.4.* || 5.5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4"


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.